### PR TITLE
Use extractVersion that also works on Linux

### DIFF
--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -35,6 +35,16 @@ join() {
 	echo "${out#$sep}"
 }
 
+extractVersion() {
+  awk '
+        $1 == "ENV" && /_VERSION/ {
+        match($2, /"v(.*)"/)
+        print substr($2, RSTART + 2, RLENGTH - 3)
+        exit
+      }'
+
+}
+
 self="${BASH_SOURCE##*/}"
 
 cat <<-EOH
@@ -47,7 +57,7 @@ EOH
 for version in "${versions[@]}"; do
 	commit="$(dirCommit "$version")"
 
-	fullVersion="$(git show "$commit":"$version/Dockerfile" | awk '$1 == "ENV" { match($2, /_VERSION="v([0-9\.]+)"/, arr); print arr[1]; exit; }')"
+	fullVersion="$(git show "$commit":"$version/Dockerfile" | extractVersion)"
 
 	versionAliases=( $fullVersion )
 	while :; do


### PR DESCRIPTION
## before fix

```
➜ docker-elixir (patch-gen-script-to-work-on-linux-too) ✗ ./generate-stackbrew-library.sh 
# this file is generated via https://github.com/c0b/docker-elixir/blob/50bb23cfce41cafeb4f6bd0a1eeeb412ddc780ca/generate-stackbrew-library.sh

Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
GitRepo: https://github.com/c0b/docker-elixir.git
awk: line 1: syntax error at or near ,
```

## after fix
```
➜ docker-elixir (patch-gen-script-to-work-on-linux-too) ✗ ./generate-stackbrew-library.sh 
# this file is generated via https://github.com/c0b/docker-elixir/blob/50bb23cfce41cafeb4f6bd0a1eeeb412ddc780ca/generate-stackbrew-library.sh

Maintainers: Mr C0B <denc716@gmail.com> (@c0b)
GitRepo: https://github.com/c0b/docker-elixir.git

Tags: 1.3.1, 1.3, latest
GitCommit: 49ebbff02fdfde9180c6dfa07f55ded968f97b53
Directory: 1.3

Tags: 1.3.1-slim, 1.3-slim, slim
GitCommit: 49ebbff02fdfde9180c6dfa07f55ded968f97b53
Directory: 1.3/slim

Tags: 1.2.6, 1.2
GitCommit: 77b9a3da43ce035327ae29083e567191d60a6ac8
Directory: 1.2

Tags: 1.2.6-slim, 1.2-slim
GitCommit: 77b9a3da43ce035327ae29083e567191d60a6ac8
Directory: 1.2/slim
```

tested with `echo 'ENV ELIXIR_VERSION="v1.3.1"' | extractVersion` and `echo 'ENV ELIXIR_VERSION="v1.3"' | extractVersion`