### PR TITLE
Upgrades elixir to 1.4.2

### DIFF
--- a/1.4/Dockerfile
+++ b/1.4/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:19
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.4.1" \
+ENV ELIXIR_VERSION="v1.4.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="c057da76e0fed7097cce468eb6e22993901f888ca32af363ac542c11a674d805"\
+	&& ELIXIR_DOWNLOAD_SHA256="3ff610166612db10d3f97895972882a6912e99628e31116d22406389c1de48cc"\
 	&& buildDeps=' \
 		unzip \
 	' \

--- a/1.4/slim/Dockerfile
+++ b/1.4/slim/Dockerfile
@@ -2,12 +2,12 @@
 FROM erlang:19-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.4.1" \
+ENV ELIXIR_VERSION="v1.4.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="c057da76e0fed7097cce468eb6e22993901f888ca32af363ac542c11a674d805"\
+	&& ELIXIR_DOWNLOAD_SHA256="3ff610166612db10d3f97895972882a6912e99628e31116d22406389c1de48cc"\
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
SHA obtained with:

```bash
wget https://github.com/elixir-lang/elixir/releases/download/v1.4.2/Precompiled.zip
sha256sum Precompiled.zip
```

Cheers :beers:!