### PR TITLE
Make Elixir 1.5.0 use OTP 20

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:19
+FROM erlang:20.0
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="1.5.0-dev@b3e6c54" \


### PR DESCRIPTION
Since part of the point of Elixir 1.5.0 is to leverage features of OTP 20, shouldn't we be running it on OTP 20?