### PR TITLE
Br/v1.5.0 rc0 on erlang 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,25 @@ language: bash
 services: docker
 
 env:
-  - VERSION=1.5 VARIANT=
-  - VERSION=1.4 VARIANT=
-  - VERSION=1.4 VARIANT=slim
-  - VERSION=1.3 VARIANT=
-  - VERSION=1.3 VARIANT=slim
+  - DIR=master
+  - DIR=1.5
+  - DIR=1.4
+  - DIR=1.4 VARIANT=slim
+  - DIR=1.3
+  - DIR=1.3 VARIANT=slim
 
 install:
-  - git clone https://github.com/docker-library/official-images.git ~/official-images
+  - curl -fsSL https://github.com/docker-library/official-images/archive/master.tar.gz | {
+      mkdir -vp ./official-images/;
+      tar -C ./official-images/ --strip-components=1 -zxvv official-images-master/test/; }
 
 before_script:
-  - env | sort
-  - cd "$VERSION"
-  - image="$(awk '$1 == "FROM" { print $2; exit }' onbuild/Dockerfile)${VARIANT:+-$VARIANT}"
+  - eval $(awk '/ELIXIR_VERSION=/ { sub(/@/, "-", $2); print $2; exit }' ${DIR}/${VARIANT}/Dockerfile)
+  - image="elixir:${ELIXIR_VERSION#v}${VARIANT:+-$VARIANT}"
 
 script:
-  - docker build --pull -t "$image" "${VARIANT:-.}"
-  - ~/official-images/test/run.sh "$image"
-# the "onbuild" variant has to happen with the base variant because it's FROM it
-  - true && [ "$VARIANT" ] || docker build -t "${image}-onbuild" onbuild
+  - docker build --pull -t "$image" "${DIR}/${VARIANT}"
+  - ./official-images/test/run.sh "$image"
 
 after_script:
   - docker images

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,20 +1,22 @@
 FROM erlang:20.0
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="1.5.0-dev@b3e6c54" \
+ENV ELIXIR_VERSION="v1.5.0-rc.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
-	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION#*@}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="0cdcd1bc54ab12291e5055f6484b0de530008179cc0354f73ed48c8de1102f2e" \
-	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
-	&& echo "$ELIXIR_DOWNLOAD_SHA256 elixir-src.tar.gz" | sha256sum -c - \
-	&& mkdir -p /usr/src/elixir-src \
-	&& tar -xzf elixir-src.tar.gz -C /usr/src/elixir-src --strip-components=1 \
-	&& rm elixir-src.tar.gz \
-	&& cd /usr/src/elixir-src \
-	&& make -j$(nproc) \
-	&& make install \
-	&& rm -rf /usr/src/elixir-src
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="8eb57f232c99f5ce667f0d20a4d8c9e2bdd13446a6186af159bc9cc279bf8243" \
+	&& buildDeps=' \
+		unzip \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
+	&& unzip -d /usr/local elixir-precompiled.zip \
+	&& rm elixir-precompiled.zip \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
 
 CMD ["iex"]

--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:19
+FROM erlang:20.0
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="1.5.0-dev@b3e6c54" \

--- a/1.5/onbuild/Dockerfile
+++ b/1.5/onbuild/Dockerfile
@@ -1,2 +1,0 @@
-
-FROM elixir:1.5

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,0 +1,20 @@
+FROM erlang:20.0
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.6.0-dev@0125cd0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION#*@}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="acc02aabd5eb733405739cfe666b0d0dc0b74ff08c4de6f8368a0f09383dc47b" \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256 elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/src/elixir-src \
+	&& tar -xzf elixir-src.tar.gz -C /usr/src/elixir-src --strip-components=1 \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/src/elixir-src \
+	&& make -j$(nproc) \
+	&& make install \
+	&& rm -rf /usr/src/elixir-src
+
+CMD ["iex"]


### PR DESCRIPTION
here are the changes to make `v1.5.0-rc.0` and `v1.6.0-dev@0125cd0` (current bleeding edge).