### PR TITLE
Add alpine variant for 1.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - DIR=master
   - DIR=1.5
   - DIR=1.5 VARIANT=slim
+  - DIR=1.5 VARIENT=alpine
   - DIR=1.4
   - DIR=1.4 VARIANT=slim
   - DIR=1.3

--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -1,0 +1,20 @@
+FROM erlang:20-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.5.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="01841d8f973e10ea2e8e29342193063efb5ebe2c598c21dc8a3b93ec8428466a" \
+	&& buildDeps="ca-certificates curl unzip" \
+  && apk update \
+  && apk add $buildDeps \
+	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
+	&& unzip -d /usr/local elixir-precompiled.zip \
+	&& rm elixir-precompiled.zip \
+  && apk del $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
+
+CMD ["iex"]


### PR DESCRIPTION
Erlang added alpine support starting with OTP 20. This PR adds an alpine variant starting with Elixir 1.5 that now officially supports OTP 20.