### PR TITLE
Upgrades elixir to 1.5.2

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.5.1" \
+ENV ELIXIR_VERSION="v1.5.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="9a903dc71800c6ce8f4f4b84a1e4849e3433e68243958fd6413a144857b61f6a" \
+	&& ELIXIR_DOWNLOAD_SHA256="7317b7a9d3b5bef2b5cd56de738f2b37fd4111e24efbe71a3e39bea1b702ff6c" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.5.1" \
+ENV ELIXIR_VERSION="v1.5.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="84af6eb4cb68d0f60b3edf4e275eb024f8eb8cccae91b18c2bbbc4b70a88934f" \
+	&& ELIXIR_DOWNLOAD_SHA256="4ba8dd46998bee6cbcc2d9937776e241be82bc62d2b62b6235c310a44c87467e" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.5/slim/Dockerfile
+++ b/1.5/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.5.1" \
+ENV ELIXIR_VERSION="v1.5.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="84af6eb4cb68d0f60b3edf4e275eb024f8eb8cccae91b18c2bbbc4b70a88934f" \
+	&& ELIXIR_DOWNLOAD_SHA256="4ba8dd46998bee6cbcc2d9937776e241be82bc62d2b62b6235c310a44c87467e" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
Version bump for elixir v1.5.2.

https://github.com/elixir-lang/elixir/releases/tag/v1.5.2

@c0b, could you please review and merge?