### PR TITLE
Elixir-1.5: use erlang-20.1.1

### DIFF
--- a/1.5/Dockerfile
+++ b/1.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:20
+FROM erlang:20.1.1
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.5.2" \

--- a/1.5/alpine/Dockerfile
+++ b/1.5/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:20-alpine
+FROM erlang:20.1.1-alpine
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.5.2" \

--- a/1.5/slim/Dockerfile
+++ b/1.5/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:20-slim
+FROM erlang:20.1.1-slim
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.5.2" \

--- a/master/Dockerfile
+++ b/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:20
+FROM erlang:20.1.1
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.6.0-dev@fba7e5c" \


### PR DESCRIPTION
[erlang-20.1.1](https://hub.docker.com/_/erlang/) images are out, might as well use them.