### PR TITLE
Upgrades elixir to 1.6.2

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.1" \
+ENV ELIXIR_VERSION="v1.6.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="91109a1774e9040fb10c1692c146c3e5a102e621e9c48196bfea7b828d54544c" \
+	&& ELIXIR_DOWNLOAD_SHA256="64779258e60ddf220fde75c9d972c00ff7760cbd0edbe555c93e3f892f8b0726" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.1" \
+ENV ELIXIR_VERSION="v1.6.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="9e1cf3651ba2a740cc4669a8b35c903801a7c8c4ea8068f951f12fc281d3c0d1" \
+	&& ELIXIR_DOWNLOAD_SHA256="e1469ed37fa40fb37f997d5b086dfd71381fc2664ce00d38d7dabafabdca14e8" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.6/slim/Dockerfile
+++ b/1.6/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.1" \
+ENV ELIXIR_VERSION="v1.6.2" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="9e1cf3651ba2a740cc4669a8b35c903801a7c8c4ea8068f951f12fc281d3c0d1" \
+	&& ELIXIR_DOWNLOAD_SHA256="e1469ed37fa40fb37f997d5b086dfd71381fc2664ce00d38d7dabafabdca14e8" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
Version 1.6.2 released yesterday: https://github.com/elixir-lang/elixir/releases/tag/v1.6.2.