### PR TITLE
Upgrade Elixir to 1.6.6

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.5" \
+ENV ELIXIR_VERSION="v1.6.6" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="defe2bed953ee729addf1121db3fa42a618ef1d6c57a1f489da03b0e7a626e89" \
+	&& ELIXIR_DOWNLOAD_SHA256="74507b0646bf485ee3af0e7727e3fdab7123f1c5ecf2187a52a928ad60f93831" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.5" \
+ENV ELIXIR_VERSION="v1.6.6" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="ba2afd91ce65ec94d460a94752fa2560391b349d0fd598847f496ee041a44b80" \
+	&& ELIXIR_DOWNLOAD_SHA256="d6a84726a042407110d3b13b1ce8d9524b4a50df68174e79d89a9e42e30b410b" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.6/slim/Dockerfile
+++ b/1.6/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:20-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.5" \
+ENV ELIXIR_VERSION="v1.6.6" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="ba2afd91ce65ec94d460a94752fa2560391b349d0fd598847f496ee041a44b80" \
+	&& ELIXIR_DOWNLOAD_SHA256="d6a84726a042407110d3b13b1ce8d9524b4a50df68174e79d89a9e42e30b410b" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
Release: https://github.com/elixir-lang/elixir/releases/tag/v1.6.6