### PR TITLE
add the alpine-otp-21 variant for image v1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - DIR=1.6
   - DIR=1.6 VARIANT=slim
   - DIR=1.6 VARIANT=alpine
+  - DIR=1.6 VARIANT=alpine-otp-21
   - DIR=1.5
   - DIR=1.5 VARIANT=slim
   - DIR=1.5 VARIANT=alpine

--- a/1.6/alpine-otp-21/Dockerfile
+++ b/1.6/alpine-otp-21/Dockerfile
@@ -1,0 +1,26 @@
+FROM erlang:21-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.6.6" \
+	LANG=C.UTF-8
+
+# the OTP_VERSION is env set from erlang images, has values like `21.1.3`
+RUN set -xe \
+	&& OTP_MAJOR_VERSION="${OTP_VERSION%%.*}" \
+	&& ELIXIR_DOWNLOAD_URL="https://repo.hex.pm/builds/elixir/${ELIXIR_VERSION}-otp-${OTP_MAJOR_VERSION}.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="883cf0cd6e46e726bbcf41e281a8987d2fbdbe0075a60f8acde52f2a0ac1cc7e" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		unzip \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
+	&& unzip -d /usr/local elixir-precompiled.zip \
+	&& rm elixir-precompiled.zip \
+	&& apk del .build-deps \
+	&& mix local.hex --force \
+	&& mix local.rebar --force
+
+CMD ["iex"]


### PR DESCRIPTION
fix #63 for https://github.com/c0b/docker-elixir/issues/63#issuecomment-399306302  I'll keep this open for a few more days as **`Request For Comments`**

```diff
diff -urNp ./1.6/alpine/Dockerfile ./1.6/alpine-otp-21/Dockerfile
--- ./1.6/alpine/Dockerfile	2018-06-25 00:23:02.015268241 -0700
+++ ./1.6/alpine-otp-21/Dockerfile	2018-06-25 05:50:14.032604012 -0700
@@ -4,9 +4,11 @@ FROM erlang:21-alpine
 ENV ELIXIR_VERSION="v1.6.6" \
 	LANG=C.UTF-8

+# the OTP_VERSION is env set from erlang images, has values like `21.1.3`
 RUN set -xe \
-	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="d6a84726a042407110d3b13b1ce8d9524b4a50df68174e79d89a9e42e30b410b" \
+	&& OTP_MAJOR_VERSION="${OTP_VERSION%%.*}" \
+	&& ELIXIR_DOWNLOAD_URL="https://repo.hex.pm/builds/elixir/${ELIXIR_VERSION}-otp-${OTP_MAJOR_VERSION}.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="883cf0cd6e46e726bbcf41e281a8987d2fbdbe0075a60f8acde52f2a0ac1cc7e" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \
@@ -17,6 +19,8 @@ RUN set -xe \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
 	&& unzip -d /usr/local elixir-precompiled.zip \
 	&& rm elixir-precompiled.zip \
-	&& apk del .build-deps
+	&& apk del .build-deps \
+	&& mix local.hex --force \
+	&& mix local.rebar --force

 CMD ["iex"]
```