### PR TITLE
new tags: `elixir:1.6-otp-21` and `elixir:1.6-otp-21-alpine`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ env:
   - DIR=1.6
   - DIR=1.6 VARIANT=slim
   - DIR=1.6 VARIANT=alpine
+  - DIR=1.6 VARIANT=otp-21
+  - DIR=1.6 VARIANT=otp-21-alpine
   - DIR=1.5
   - DIR=1.5 VARIANT=slim
   - DIR=1.5 VARIANT=alpine
-  - DIR=1.4
-  - DIR=1.4 VARIANT=slim
 
 install:
   - curl -fsSL https://github.com/docker-library/official-images/archive/master.tar.gz | {

--- a/1.6/otp-21-alpine/Dockerfile
+++ b/1.6/otp-21-alpine/Dockerfile
@@ -1,0 +1,26 @@
+FROM erlang:21-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.6.6" \
+	LANG=C.UTF-8
+
+# the OTP_VERSION is env set from erlang images, has values like `21.1.3`
+RUN set -xe \
+	&& OTP_MAJOR_VERSION="${OTP_VERSION%%.*}" \
+	&& ELIXIR_DOWNLOAD_URL="https://repo.hex.pm/builds/elixir/${ELIXIR_VERSION}-otp-${OTP_MAJOR_VERSION}.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="883cf0cd6e46e726bbcf41e281a8987d2fbdbe0075a60f8acde52f2a0ac1cc7e" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		unzip \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
+	&& unzip -d /usr/local elixir-precompiled.zip \
+	&& rm elixir-precompiled.zip \
+	&& apk del .build-deps \
+	&& mix local.hex --force \
+	&& mix local.rebar --force
+
+CMD ["iex"]

--- a/1.6/otp-21/Dockerfile
+++ b/1.6/otp-21/Dockerfile
@@ -1,0 +1,18 @@
+FROM erlang:21
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.6.6" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="74507b0646bf485ee3af0e7727e3fdab7123f1c5ecf2187a52a928ad60f93831" \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean
+
+CMD ["iex"]


### PR DESCRIPTION
use new tags `elixir:1.6-otp-21` and `elixir:1.6-otp-21-alpine` for those
who like to try latest bleeding edge versions.

closes #70 keep this open for some more days comments