### PR TITLE
revert the main elixir:1.6 series images to be based on erlang:20

### DIFF
--- a/1.6/Dockerfile
+++ b/1.6/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:21
+FROM erlang:20
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.6.6" \

--- a/1.6/alpine/Dockerfile
+++ b/1.6/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:21-alpine
+FROM erlang:20-alpine
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.6.6" \

--- a/1.6/slim/Dockerfile
+++ b/1.6/slim/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:21-slim
+FROM erlang:20-slim
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.6.6" \


### PR DESCRIPTION
to change a base Erlang image's major version during the middle of
an Elixir major version's life time is not good, caused problems like
in #72 #71 (and more);

we can build a better strategy of upgrading:
1. when a new Elixir major version is released, choose the latest Erlang version
   at that time and use it for the whole life time of that Elixir major version;
2. when newer Erlang major versions come during middle of an Elixir major version's
   lifetime, we can release other images like `elixir:1.6-otp-21*` in #73