### PR TITLE
add the elixir v1.7.0-rc.0

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,0 +1,18 @@
+FROM erlang:21
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.7.0-rc.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION#*@}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="5b60db27e1256aae70012a3957dcc1e2911390a97385539b3c962f336341ef56" \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean
+
+CMD ["iex"]

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -1,0 +1,22 @@
+FROM erlang:21-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.7.0-rc.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="c0e2ebe8120d840125c54a4be6e6b3e3201047700cccbc33617f3b6d1c35e1e9" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		unzip \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
+	&& unzip -d /usr/local elixir-precompiled.zip \
+	&& rm elixir-precompiled.zip \
+	&& apk del .build-deps
+
+CMD ["iex"]

--- a/1.7/slim/Dockerfile
+++ b/1.7/slim/Dockerfile
@@ -1,0 +1,24 @@
+FROM erlang:21-slim
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.7.0-rc.0" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="c0e2ebe8120d840125c54a4be6e6b3e3201047700cccbc33617f3b6d1c35e1e9" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		unzip \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
+	&& unzip -d /usr/local elixir-precompiled.zip \
+	&& rm elixir-precompiled.zip \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
+
+CMD ["iex"]


### PR DESCRIPTION
the v1.7 images' whole life cycle will be sticking with `Erlang:21`  and will release similar `v1.7-otp-22` tags when erlang:22 coming in next year;

the `-rc` images won't be pushed to docker hub, you can build local if you're interested

```diff
$ diff -urNp ./1.6 ./1.7
diff -urNp ./1.6/alpine/Dockerfile ./1.7/alpine/Dockerfile
--- ./1.6/alpine/Dockerfile	2018-07-06 07:10:16.698985673 -0700
+++ ./1.7/alpine/Dockerfile	2018-07-13 07:49:55.147879436 -0700
@@ -1,12 +1,12 @@
-FROM erlang:20-alpine
+FROM erlang:21-alpine

 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.6" \
+ENV ELIXIR_VERSION="v1.7.0-rc.0" \
 	LANG=C.UTF-8

 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="d6a84726a042407110d3b13b1ce8d9524b4a50df68174e79d89a9e42e30b410b" \
+	&& ELIXIR_DOWNLOAD_SHA256="c0e2ebe8120d840125c54a4be6e6b3e3201047700cccbc33617f3b6d1c35e1e9" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \
diff -urNp ./1.6/Dockerfile ./1.7/Dockerfile
--- ./1.6/Dockerfile	2018-07-06 07:09:52.001800046 -0700
+++ ./1.7/Dockerfile	2018-07-13 07:38:33.199637821 -0700
@@ -1,12 +1,12 @@
-FROM erlang:20
+FROM erlang:21

 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.6" \
+ENV ELIXIR_VERSION="v1.7.0-rc.0" \
 	LANG=C.UTF-8

 RUN set -xe \
-	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="74507b0646bf485ee3af0e7727e3fdab7123f1c5ecf2187a52a928ad60f93831" \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION#*@}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="5b60db27e1256aae70012a3957dcc1e2911390a97385539b3c962f336341ef56" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \
diff -urNp ./1.6/slim/Dockerfile ./1.7/slim/Dockerfile
--- ./1.6/slim/Dockerfile	2018-07-06 07:10:03.774888534 -0700
+++ ./1.7/slim/Dockerfile	2018-07-13 07:46:00.447075470 -0700
@@ -1,12 +1,12 @@
-FROM erlang:20-slim
+FROM erlang:21-slim

 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.6.6" \
+ENV ELIXIR_VERSION="v1.7.0-rc.0" \
 	LANG=C.UTF-8

 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="d6a84726a042407110d3b13b1ce8d9524b4a50df68174e79d89a9e42e30b410b" \
+	&& ELIXIR_DOWNLOAD_SHA256="c0e2ebe8120d840125c54a4be6e6b3e3201047700cccbc33617f3b6d1c35e1e9" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \
```