### PR TITLE
Updating Elixir to 1.7.0

### DIFF
--- a/1.7/Dockerfile
+++ b/1.7/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:21
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.7.0-rc.1" \
+ENV ELIXIR_VERSION="v1.7.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION#*@}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="022f290a9bfa6bd8d9f42268199c02bfcd15f9dfaece527d9876c891c8418217" \
+	&& ELIXIR_DOWNLOAD_SHA256="791f726f7e3bb05a4620beb6191f2d758332ea7a169861b03580a16022c49a75" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:21-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.7.0-rc.1" \
+ENV ELIXIR_VERSION="v1.7.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="a9f082905238b3112daf47b27566ff3e2ff201451fda140d2eeff84cf8e5b3df" \
+	&& ELIXIR_DOWNLOAD_SHA256="19863a565875f4aaebb73de09f85c22d07b45d0e61d1e6bf5eb4b8e632569665" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.7/slim/Dockerfile
+++ b/1.7/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:21-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.7.0-rc.1" \
+ENV ELIXIR_VERSION="v1.7.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="a9f082905238b3112daf47b27566ff3e2ff201451fda140d2eeff84cf8e5b3df" \
+	&& ELIXIR_DOWNLOAD_SHA256="19863a565875f4aaebb73de09f85c22d07b45d0e61d1e6bf5eb4b8e632569665" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
This uses the final 1.7 version, released yesterday.