### PR TITLE
Use precompiled release for OTP 21 in 1.7 Images

### DIFF
--- a/1.7/alpine/Dockerfile
+++ b/1.7/alpine/Dockerfile
@@ -2,11 +2,12 @@ FROM erlang:21-alpine
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.7.2" \
+	ERLANG_MAJOR_VERSION="21" \
 	LANG=C.UTF-8
 
 RUN set -xe \
-	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="d39c0fcdd2053f0ae2a9b1394ee582ac3398d9538881024f2252688ad92aad86" \
+	&& ELIXIR_DOWNLOAD_URL="https://repo.hex.pm/builds/elixir/${ELIXIR_VERSION#*@}-otp-${ERLANG_MAJOR_VERSION#*@}.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="7790fb5d63045e4b3c5482dde05abe90b417b00d532ca4dfd1c1295d0367e777" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.7/slim/Dockerfile
+++ b/1.7/slim/Dockerfile
@@ -2,11 +2,12 @@ FROM erlang:21-slim
 
 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.7.2" \
+	ERLANG_MAJOR_VERSION="21" \
 	LANG=C.UTF-8
 
 RUN set -xe \
-	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/releases/download/${ELIXIR_VERSION}/Precompiled.zip" \
-	&& ELIXIR_DOWNLOAD_SHA256="d39c0fcdd2053f0ae2a9b1394ee582ac3398d9538881024f2252688ad92aad86" \
+	&& ELIXIR_DOWNLOAD_URL="https://repo.hex.pm/builds/elixir/${ELIXIR_VERSION#*@}-otp-${ERLANG_MAJOR_VERSION#*@}.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="7790fb5d63045e4b3c5482dde05abe90b417b00d532ca4dfd1c1295d0367e777" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
Precompiled images using an older version than OTP 21 are not fully compatible with OTP 21.

[As suggested by michalmuskala](https://github.com/elixir-lang/elixir/issues/5851#issuecomment-414292794), binaries precompiled with OTP 21 are provided by the Hex team.

We should use those to ensure working images.