### PR TITLE
Add a new variant elixir:1.8-otp-22 for those brave souls to play with

### DIFF
--- a/1.8/otp-22-alpine/Dockerfile
+++ b/1.8/otp-22-alpine/Dockerfile
@@ -1,0 +1,25 @@
+FROM erlang:22-alpine
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.8.2" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="cf9bf0b2d92bc4671431e3fe1d1b0a0e5125f1a942cc4fdf7914b74f04efb835" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		make \
+	' \
+	&& apk add --no-cache --virtual .build-deps $buildDeps \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean \
+	&& apk del .build-deps
+
+CMD ["iex"]

--- a/1.8/otp-22/Dockerfile
+++ b/1.8/otp-22/Dockerfile
@@ -1,0 +1,18 @@
+FROM erlang:22
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.8.2" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
+	&& ELIXIR_DOWNLOAD_SHA256="cf9bf0b2d92bc4671431e3fe1d1b0a0e5125f1a942cc4fdf7914b74f04efb835" \
+	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
+	&& mkdir -p /usr/local/src/elixir \
+	&& tar -xzC /usr/local/src/elixir --strip-components=1 -f elixir-src.tar.gz \
+	&& rm elixir-src.tar.gz \
+	&& cd /usr/local/src/elixir \
+	&& make install clean
+
+CMD ["iex"]


### PR DESCRIPTION
https://github.com/c0b/docker-elixir/pull/113#issuecomment-496077697 The next Elixir:1.9 will start with Erlang OTP-22.

```console
➸ docker image ls
REPOSITORY          TAG                    IMAGE ID            CREATED             SIZE
elixir              v1.8-otp-22-alpine     8e4dfdfb25bf        4 seconds ago       87.2MB
elixir              v1.8-otp-22            fbd756173e1b        2 minutes ago       1.08GB
elixir              v1.8-otp-21.2-alpine   d559f14013c6        7 minutes ago       86.9MB
elixir              v1.8-otp-21.2          9f523d60c425        10 minutes ago      1.08GB
elixir              v1.8-alpine            fccea8285aa4        11 minutes ago      87.2MB
elixir              v1.8-slim              edec74f507c5        12 minutes ago      266MB
elixir              v1.8                   2f655b2cac32        13 minutes ago      1.08GB
```

```console
➸ diff -urNp ./1.8/Dockerfile ./1.8/otp-22/Dockerfile
--- ./1.8/Dockerfile	2019-05-27 00:14:05.011931183 -0500
+++ ./1.8/otp-22/Dockerfile	2019-05-27 00:46:18.262908094 -0500
@@ -1,4 +1,4 @@
-FROM erlang:21
+FROM erlang:22

 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.8.2" \

➸ diff -urNp ./1.8/alpine/Dockerfile ./1.8/otp-22-alpine/Dockerfile
--- ./1.8/alpine/Dockerfile	2019-05-27 00:14:05.011931183 -0500
+++ ./1.8/otp-22-alpine/Dockerfile	2019-05-27 00:46:18.262908094 -0500
@@ -1,4 +1,4 @@
-FROM erlang:21-alpine
+FROM erlang:22-alpine

 # elixir expects utf8.
 ENV ELIXIR_VERSION="v1.8.2" \
```