### PR TITLE
bump Elixir v1.9 from rc.0 to released version

### DIFF
--- a/1.9/Dockerfile
+++ b/1.9/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:22
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.9.0-rc.0" \
+ENV ELIXIR_VERSION="v1.9.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="fa019ba18556f53bfb77840b0970afd116517764251704b55e419becb0b384cf" \
+	&& ELIXIR_DOWNLOAD_SHA256="dbf4cb66634e22d60fe4aa162946c992257f700c7db123212e7e29d1c0b0c487" \
 	&& curl -fSL -o elixir-src.tar.gz $ELIXIR_DOWNLOAD_URL \
 	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-src.tar.gz" | sha256sum -c - \
 	&& mkdir -p /usr/local/src/elixir \

--- a/1.9/alpine/Dockerfile
+++ b/1.9/alpine/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:22-alpine
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.9.0-rc.0" \
+ENV ELIXIR_VERSION="v1.9.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="fa019ba18556f53bfb77840b0970afd116517764251704b55e419becb0b384cf" \
+	&& ELIXIR_DOWNLOAD_SHA256="dbf4cb66634e22d60fe4aa162946c992257f700c7db123212e7e29d1c0b0c487" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \

--- a/1.9/slim/Dockerfile
+++ b/1.9/slim/Dockerfile
@@ -1,12 +1,12 @@
 FROM erlang:22-slim
 
 # elixir expects utf8.
-ENV ELIXIR_VERSION="v1.9.0-rc.0" \
+ENV ELIXIR_VERSION="v1.9.0" \
 	LANG=C.UTF-8
 
 RUN set -xe \
 	&& ELIXIR_DOWNLOAD_URL="https://github.com/elixir-lang/elixir/archive/${ELIXIR_VERSION}.tar.gz" \
-	&& ELIXIR_DOWNLOAD_SHA256="fa019ba18556f53bfb77840b0970afd116517764251704b55e419becb0b384cf" \
+	&& ELIXIR_DOWNLOAD_SHA256="dbf4cb66634e22d60fe4aa162946c992257f700c7db123212e7e29d1c0b0c487" \
 	&& buildDeps=' \
 		ca-certificates \
 		curl \


### PR DESCRIPTION
Elixir v1.9 [was released today](https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/). This bumps the Dockerfile from rc0 to the released version, which is available [here](https://github.com/elixir-lang/elixir/releases/tag/v1.9.0). Please verify the sha256sum 🙂 