### PR TITLE
Add 1.5.3-otp-18, 1.5.3-otp-19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
   - DIR=1.5 VARIANT=slim
   - DIR=1.5 VARIANT=alpine
   - DIR=1.5 VARIANT=otp-18-slim
+  - DIR=1.5 VARIANT=otp-19-slim
 
 install:
   - curl -fsSL https://github.com/docker-library/official-images/archive/master.tar.gz | {

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
   - DIR=1.5
   - DIR=1.5 VARIANT=slim
   - DIR=1.5 VARIANT=alpine
+  - DIR=1.5 VARIANT=otp-18-slim
 
 install:
   - curl -fsSL https://github.com/docker-library/official-images/archive/master.tar.gz | {

--- a/1.5/otp-18-slim/Dockerfile
+++ b/1.5/otp-18-slim/Dockerfile
@@ -1,0 +1,25 @@
+FROM erlang:18-slim
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.5.3" \
+  OTP_MAJOR_VERSION="18" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://repo.hex.pm/builds/elixir/${ELIXIR_VERSION}-otp-${OTP_MAJOR_VERSION}.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="9c51a630dcab58b0bbc03d1353b7d5ab244ed7dddf3743fd62d76f9a0fee1363" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		unzip \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
+	&& unzip -d /usr/local elixir-precompiled.zip \
+	&& rm elixir-precompiled.zip \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
+
+CMD ["iex"]

--- a/1.5/otp-19-slim/Dockerfile
+++ b/1.5/otp-19-slim/Dockerfile
@@ -1,0 +1,25 @@
+FROM erlang:19-slim
+
+# elixir expects utf8.
+ENV ELIXIR_VERSION="v1.5.3" \
+  OTP_MAJOR_VERSION="19" \
+	LANG=C.UTF-8
+
+RUN set -xe \
+	&& ELIXIR_DOWNLOAD_URL="https://repo.hex.pm/builds/elixir/${ELIXIR_VERSION}-otp-${OTP_MAJOR_VERSION}.zip" \
+	&& ELIXIR_DOWNLOAD_SHA256="99ab05aa0f080c6e62990f22c5e5d99e8ee6fef043d0b4192fdab94cf99dfe31" \
+	&& buildDeps=' \
+		ca-certificates \
+		curl \
+		unzip \
+	' \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends $buildDeps \
+	&& curl -fSL -o elixir-precompiled.zip $ELIXIR_DOWNLOAD_URL \
+	&& echo "$ELIXIR_DOWNLOAD_SHA256  elixir-precompiled.zip" | sha256sum -c - \
+	&& unzip -d /usr/local elixir-precompiled.zip \
+	&& rm elixir-precompiled.zip \
+	&& apt-get purge -y --auto-remove $buildDeps \
+	&& rm -rf /var/lib/apt/lists/*
+
+CMD ["iex"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -71,7 +71,7 @@ for version in "${versions[@]}"; do
 	done
 	versionAliases+=( $version ${aliases[$version]:-} )
 
-	for variant in '' slim alpine otp-{21,22}{,-alpine}; do
+	for variant in '' slim alpine otp-{18,19,20,21,22}{,-alpine,-slim}; do
 		dir="$version${variant:+/$variant}"
 		[ -f "$dir/Dockerfile" ] || continue
 


### PR DESCRIPTION
This adds

- 1.5.3-otp-18
- 1.5.3-otp-19

1.5.3-otp-20 seems to already exist, but is tagged as 1.5.3

These use the hex.pm Bob-built versions since the precompiled artifacts on GitHub for these OTP versions don't exist.