### PR TITLE
change image layers url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Stars](https://img.shields.io/docker/stars/_/elixir.svg?style=flat-square)](https://hub.docker.com/_/elixir/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/_/elixir.svg?style=flat-square)](https://hub.docker.com/_/elixir/)
-[![Image Layers](https://badge.imagelayers.io/elixir:latest.svg)](https://imagelayers.io/?images=elixir:latest 'Show Image Layers at imagelayers.io')
+[![Image Layers](https://images.microbadger.com/badges/image/elixir.svg)](https://microbadger.com/images/elixir "Get your own image badge on microbadger.com")
 
 [![Build Status](https://travis-ci.org/c0b/docker-elixir.svg?branch=master)](https://travis-ci.org/c0b/docker-elixir)
 


### PR DESCRIPTION
I notice that the url is broken, and the issue also links to microscaling/imagelayers-graph#96.